### PR TITLE
"Query already executed" error

### DIFF
--- a/lib/pool.ts
+++ b/lib/pool.ts
@@ -36,34 +36,35 @@ export function addEventToPool(thePromise: PromiseToProcess, callbacks?: Callbac
   let resolvedEvent: any;
 
   // Attach Promise's event handlers
-  thePromise.then((payload: any) => {
-    if (callbacks && callbacks.then) {
-      callbacks.then(payload, eventToProcess);
-    }
-    resolvedEvent = payload;
-    consoleLog(`Event with id: ${eventToProcess.id} completed successfully.`);
-  });
-  thePromise.catch((err: unknown) => {
-    if (callbacks && callbacks.catch) {
-      callbacks.catch(err, eventToProcess);
-    }
-    consoleLog(`Event with id: ${eventToProcess.id} failed to complete.`);
-  });
-  thePromise.finally(() => {
-    // Remove the completed/failed item from the pool
-    const index = pool.indexOf(eventToProcess);
-    if (index > -1) {
-      pool.splice(index, 1);
-    }
-    if (callbacks && callbacks.finally) {
-      callbacks.finally();
-    }
-    consoleLog(`Slot freed for event id: ${eventToProcess.id}`);
-    // Callback to notify when there's an available slot in the pool
-    if (onOpenSlotCallback) {
-      onOpenSlotCallback();
-    }
-  });
+  thePromise
+    .then((payload: any) => {
+      if (callbacks && callbacks.then) {
+        callbacks.then(payload, eventToProcess);
+      }
+      resolvedEvent = payload;
+      consoleLog(`Event with id: ${eventToProcess.id} completed successfully.`);
+    })
+    .catch((err: unknown) => {
+      if (callbacks && callbacks.catch) {
+        callbacks.catch(err, eventToProcess);
+      }
+      consoleLog(`Event with id: ${eventToProcess.id} failed to complete.`);
+    })
+    .finally(() => {
+      // Remove the completed/failed item from the pool
+      const index = pool.indexOf(eventToProcess);
+      if (index > -1) {
+        pool.splice(index, 1);
+      }
+      if (callbacks && callbacks.finally) {
+        callbacks.finally();
+      }
+      consoleLog(`Slot freed for event id: ${eventToProcess.id}`);
+      // Callback to notify when there's an available slot in the pool
+      if (onOpenSlotCallback) {
+        onOpenSlotCallback();
+      }
+    });
 
   // Add the newly created event object to the pool
   pool.push(eventToProcess);

--- a/lib/pool.ts
+++ b/lib/pool.ts
@@ -62,7 +62,7 @@ export function addEventToPool(thePromise: PromiseToProcess, callbacks?: Callbac
       consoleLog(`Slot freed for event id: ${eventToProcess.id}`);
       // Callback to notify when there's an available slot in the pool
       if (onOpenSlotCallback) {
-        onOpenSlotCallback();
+        onOpenSlotCallback(resolvedEvent);
       }
     });
 

--- a/lib/pool.ts
+++ b/lib/pool.ts
@@ -32,11 +32,15 @@ export function addEventToPool(thePromise: PromiseToProcess, callbacks?: Callbac
     promise: thePromise,
   };
 
+  // To be able to use the resolved event in the finally block
+  let resolvedEvent: any;
+
   // Attach Promise's event handlers
   thePromise.then((payload: any) => {
     if (callbacks && callbacks.then) {
       callbacks.then(payload, eventToProcess);
     }
+    resolvedEvent = payload;
     consoleLog(`Event with id: ${eventToProcess.id} completed successfully.`);
   });
   thePromise.catch((err: unknown) => {


### PR DESCRIPTION
## Issue

After adding a promise to the promise pool, the `.finally` block would return an error of "query already executed". This is because the promise gets executed in the initial `thePromise.then()`. By the time it reaches `thePromise.finally()`, the promise has already been ran.

## Solution

By chaining the `.catch` and `.finally` onto the `.then`, we can avoid this issue while still accomplishing the original goal of attaching the custom event handlers.

## Additional changes

A `resolvedEvent` variable has been declared so that we can pass the resolved event to the finally block, which can then be used in the `onOpenSlotCallback`.